### PR TITLE
Fix the path to the platform_build project

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -422,7 +422,7 @@
   <project path="tools/swt" name="platform/tools/swt" groups="notdefault,tools" />
 
   <!-- Asteroid specific repositories -->
-  <project path="build" name="platform_build" remote="github" revision="master" >
+  <project path="build" name="AsteroidOS/android_build" remote="github" revision="master" >
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="bionic" name="Asteroid-Project/android_bionic" remote="github" revision="master" />


### PR DESCRIPTION
`repo sync` would fail with a 404 Not Found error when using
name="platform_build". Point it to the correct repository.

```
$ repo sync -qc -j1
Fetching projects:  99% (400/404)
fatal: repository 'https://github.com/platform_build/' not found
fatal: repository 'https://github.com/platform_build/' not found
error: Cannot fetch platform_build

error: Exited sync due to fetch errors
```
